### PR TITLE
feat: Sales pagination with admin security and DB-level aggregation

### DIFF
--- a/be-app/pom.xml
+++ b/be-app/pom.xml
@@ -10,11 +10,11 @@
 		<relativePath/>
 	</parent>
 
-	<groupId>com.crafts</groupId>
-	<artifactId>crafts-be</artifactId>
+	<groupId>com.mckcreation</groupId>
+	<artifactId>be-app</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
-	<name>crafts-be</name>
-	<description>Backend application for carols crafts</description>
+	<name>be-app</name>
+	<description>Backend application for Mckcreation</description>
 
 	<properties>
 		<java.version>17</java.version>
@@ -22,7 +22,6 @@
 	</properties>
 
 	<dependencies>
-		<!-- Existing dependencies -->
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/be-app/src/main/java/com/mckcreation/be_app/BeAppApplication.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/BeAppApplication.java
@@ -2,10 +2,14 @@ package com.mckcreation.be_app;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
 
 @SpringBootApplication
+@EntityScan(basePackages = {"com.mckcreation.be_app.model"})
 public class BeAppApplication {
-	public static void main(String[] args) {
-		SpringApplication.run(BeAppApplication.class, args);
-	}
+
+    public static void main(String[] args) {
+        SpringApplication.run(BeAppApplication.class, args);
+    }
+
 }

--- a/be-app/src/main/java/com/mckcreation/be_app/controller/PlacedOrderController.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/controller/PlacedOrderController.java
@@ -1,11 +1,13 @@
 package com.mckcreation.be_app.controller;
 
+import com.mckcreation.be_app.dto.responses.SalesSummaryDTO;
 import com.mckcreation.be_app.model.PlacedOrder;
 import com.mckcreation.be_app.model.User;
 import com.mckcreation.be_app.service.PlacedOrderService;
 import com.mckcreation.be_app.service.ShippingService;
 import com.mckcreation.be_app.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -15,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/placed-order")
+@RequestMapping("/api/placed-orders")
 public class PlacedOrderController {
 
     PlacedOrderService placedOrderService;
@@ -30,10 +32,18 @@ public class PlacedOrderController {
         this.userService = userService;
     }
 
-    @GetMapping("/get-all")
-    public ResponseEntity<?> getPlacedOrders() {
-        List<PlacedOrder> placedOrders = placedOrderService.getPlacedOrders();
-        return new ResponseEntity<>(placedOrders, HttpStatus.OK);
+    @GetMapping
+    public ResponseEntity<Page<PlacedOrder>> getPlacedOrders(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<PlacedOrder> placedOrders = placedOrderService.getPlacedOrders(page, size);
+        return ResponseEntity.ok(placedOrders);
+    }
+
+    @GetMapping("/sales-summary")
+    public ResponseEntity<SalesSummaryDTO> getSalesSummary() {
+        SalesSummaryDTO salesSummary = placedOrderService.getSalesSummary();
+        return ResponseEntity.ok(salesSummary);
     }
 
     @GetMapping("/get-user-orders")

--- a/be-app/src/main/java/com/mckcreation/be_app/dto/responses/SalesSummaryDTO.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/dto/responses/SalesSummaryDTO.java
@@ -1,0 +1,15 @@
+package com.mckcreation.be_app.dto.responses;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class SalesSummaryDTO {
+    private double dailySales;
+    private double monthlySales;
+    private double yearlySales;
+    private double allTimeSales;
+}

--- a/be-app/src/main/java/com/mckcreation/be_app/repository/PlacedOrderRepository.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/repository/PlacedOrderRepository.java
@@ -20,4 +20,16 @@ public interface PlacedOrderRepository extends JpaRepository<PlacedOrder, Long> 
 
     @Query("SELECT count(o) FROM PlacedOrder o")
     long countPlacedOrders();
+
+    @Query("SELECT COALESCE(SUM(o.amount), 0) FROM PlacedOrder o WHERE CAST(o.orderDate AS date) = CURRENT_DATE")
+    double sumDailySales();
+
+    @Query("SELECT COALESCE(SUM(o.amount), 0) FROM PlacedOrder o WHERE YEAR(o.orderDate) = YEAR(CURRENT_DATE) AND MONTH(o.orderDate) = MONTH(CURRENT_DATE)")
+    double sumMonthlySales();
+
+    @Query("SELECT COALESCE(SUM(o.amount), 0) FROM PlacedOrder o WHERE YEAR(o.orderDate) = YEAR(CURRENT_DATE)")
+    double sumYearlySales();
+
+    @Query("SELECT COALESCE(SUM(o.amount), 0) FROM PlacedOrder o")
+    double sumAllTimeSales();
 }

--- a/be-app/src/main/java/com/mckcreation/be_app/repository/PlacedOrderRepository.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/repository/PlacedOrderRepository.java
@@ -1,7 +1,7 @@
 package com.mckcreation.be_app.repository;
 
-import com.mckcreation.be_app.model.Item;
 import com.mckcreation.be_app.model.PlacedOrder;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -11,15 +11,13 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface PlacedOrderRepository extends JpaRepository<PlacedOrder, Integer> {
+public interface PlacedOrderRepository extends JpaRepository<PlacedOrder, Long> {
+    @Query("SELECT o FROM PlacedOrder o WHERE o.user.id = :userId")
+    List<PlacedOrder> findAllUserPlacedOrders(@Param("userId") int userId);
 
-    @Query("SELECT placedOrder FROM PlacedOrder placedOrder WHERE placedOrder.user.id = :userID")
-    List<PlacedOrder> findAllUserPlacedOrders(@Param("userID") int userID);
+    @Query("SELECT o FROM PlacedOrder o WHERE o.user.id = :userId")
+    Page<PlacedOrder> findUserPlacedOrders(@Param("userId") long userId, Pageable pageable);
 
-    @Query("SELECT COUNT(*) FROM PlacedOrder placedOrder")
-    int countPlacedOrders();
-
-    @Query("SELECT placedOrder FROM PlacedOrder placedOrder WHERE placedOrder.user.id = :userID " +
-            "ORDER BY placedOrder.createdAt DESC")
-    List<PlacedOrder> findUserPlacedOrders(@Param("userID") long userID, Pageable pageable);
+    @Query("SELECT count(o) FROM PlacedOrder o")
+    long countPlacedOrders();
 }

--- a/be-app/src/main/java/com/mckcreation/be_app/security/config/SecurityConfig.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/security/config/SecurityConfig.java
@@ -4,10 +4,16 @@ import com.mckcreation.be_app.security.filter.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -20,6 +26,8 @@ public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final AuthenticationProvider authenticationProvider;
+
+    private final UserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -34,7 +42,6 @@ public class SecurityConfig {
                         .requestMatchers("/api/shipping/get-user-shipping").authenticated()
                         .requestMatchers("/api/user/update").authenticated()
                         .requestMatchers("/api/user/get-user-shipping").authenticated()
-                        .requestMatchers("/api/order/get-orders").authenticated()
                         .requestMatchers("/api/order/get-orders").authenticated()
                         .requestMatchers("/api/placed-order/get-user-orders").authenticated()
                         .requestMatchers("/api/order/delete/{orderID}").authenticated()
@@ -51,12 +58,30 @@ public class SecurityConfig {
                         .requestMatchers("/api/category/{id}").hasRole("ADMIN")
                         .requestMatchers("/api/category/delete/{id}").hasRole("ADMIN")
                         .requestMatchers("/api/user/get-all").hasRole("ADMIN")
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 )
                 .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authenticationProvider(authenticationProvider)
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .build();
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider(){
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(userDetailsService);
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 
 

--- a/be-app/src/main/java/com/mckcreation/be_app/security/config/SecurityConfig.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/security/config/SecurityConfig.java
@@ -55,6 +55,8 @@ public class SecurityConfig {
                         .requestMatchers("/api/item/update/{id}").hasRole("ADMIN")
                         .requestMatchers("/api/item/delete/{id}").hasRole("ADMIN")
                         .requestMatchers("/api/placed-order/get-all").hasRole("ADMIN")
+                        .requestMatchers("/api/placed-orders").hasRole("ADMIN")
+                        .requestMatchers("/api/placed-orders/sales-summary").hasRole("ADMIN")
                         .requestMatchers("/api/category/{id}").hasRole("ADMIN")
                         .requestMatchers("/api/category/delete/{id}").hasRole("ADMIN")
                         .requestMatchers("/api/user/get-all").hasRole("ADMIN")

--- a/be-app/src/main/java/com/mckcreation/be_app/service/PlacedOrderService.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/service/PlacedOrderService.java
@@ -2,7 +2,9 @@ package com.mckcreation.be_app.service;
 
 import com.mckcreation.be_app.dto.PlacedOrderDTO;
 import com.mckcreation.be_app.dto.responses.PlacedOrdersAndCountDTO;
+import com.mckcreation.be_app.dto.responses.SalesSummaryDTO;
 import com.mckcreation.be_app.model.PlacedOrder;
+import org.springframework.data.domain.Page;
 
 import java.util.List;
 
@@ -15,4 +17,7 @@ public interface PlacedOrderService {
     PlacedOrdersAndCountDTO getUserPlacedOrders(long id, int page, int size);
 
     PlacedOrder createPlacedOrder(PlacedOrderDTO placedOrderDTO, boolean useDefaultAddress);
+
+    Page<PlacedOrder> getPlacedOrders(int page, int size);
+    SalesSummaryDTO getSalesSummary();
 }

--- a/be-app/src/main/java/com/mckcreation/be_app/service/impl/PlacedOrderServiceImpl.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/service/impl/PlacedOrderServiceImpl.java
@@ -22,7 +22,6 @@ import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class PlacedOrderServiceImpl implements PlacedOrderService {
@@ -185,30 +184,12 @@ public class PlacedOrderServiceImpl implements PlacedOrderService {
 
     @Override
     public SalesSummaryDTO getSalesSummary() {
-        List<PlacedOrder> allOrders = placedOrderRepository.findAll();
-
-        LocalDateTime now = LocalDateTime.now();
-
-        double dailySales = allOrders.stream()
-                .filter(order -> order.getOrderDate().toLocalDate().isEqual(now.toLocalDate()))
-                .mapToDouble(PlacedOrder::getAmount)
-                .sum();
-
-        double monthlySales = allOrders.stream()
-                .filter(order -> order.getOrderDate().getMonth().equals(now.getMonth()) && order.getOrderDate().getYear() == now.getYear())
-                .mapToDouble(PlacedOrder::getAmount)
-                .sum();
-
-        double yearlySales = allOrders.stream()
-                .filter(order -> order.getOrderDate().getYear() == now.getYear())
-                .mapToDouble(PlacedOrder::getAmount)
-                .sum();
-
-        double allTimeSales = allOrders.stream()
-                .mapToDouble(PlacedOrder::getAmount)
-                .sum();
-
-        return new SalesSummaryDTO(dailySales, monthlySales, yearlySales, allTimeSales);
+        return new SalesSummaryDTO(
+                placedOrderRepository.sumDailySales(),
+                placedOrderRepository.sumMonthlySales(),
+                placedOrderRepository.sumYearlySales(),
+                placedOrderRepository.sumAllTimeSales()
+        );
     }
     // END of new methods
 

--- a/be-app/src/main/java/com/mckcreation/be_app/service/impl/PlacedOrderServiceImpl.java
+++ b/be-app/src/main/java/com/mckcreation/be_app/service/impl/PlacedOrderServiceImpl.java
@@ -1,6 +1,8 @@
 package com.mckcreation.be_app.service.impl;
+
 import com.mckcreation.be_app.dto.PlacedOrderDTO;
 import com.mckcreation.be_app.dto.responses.PlacedOrdersAndCountDTO;
+import com.mckcreation.be_app.dto.responses.SalesSummaryDTO;
 import com.mckcreation.be_app.model.PlacedOrder;
 import com.mckcreation.be_app.model.Shipping;
 import com.mckcreation.be_app.model.User;
@@ -12,12 +14,15 @@ import com.mckcreation.be_app.service.EmailService;
 import com.mckcreation.be_app.service.PlacedOrderService;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class PlacedOrderServiceImpl implements PlacedOrderService {
@@ -58,13 +63,12 @@ public class PlacedOrderServiceImpl implements PlacedOrderService {
         Timestamp timestamp = new Timestamp(date.getTime());
 
         PlacedOrder placedOrder = PlacedOrder.builder()
-                .orderDetails(placedOrderDTO.getDetails())
-                .total(placedOrderDTO.getTotal())
+                .orderDescription(placedOrderDTO.getDetails())
+                .amount(placedOrderDTO.getTotal())
                 .status(placedOrderDTO.getStatus())
                 .shipping(shipping)
                 .user(user)
-                .createdAt(timestamp)
-                .updatedAt(timestamp)
+                .orderDate(LocalDateTime.now()) // Assuming current time as order date
                 .build();
 
         PlacedOrder savedPlacedOrder = placedOrderRepository.save(placedOrder);
@@ -95,7 +99,7 @@ public class PlacedOrderServiceImpl implements PlacedOrderService {
     public PlacedOrdersAndCountDTO getUserPlacedOrders(long id, int page, int size) {
 
         return PlacedOrdersAndCountDTO.builder()
-                .placedOrderList(placedOrderRepository.findUserPlacedOrders(id, PageRequest.of(page, size)))
+                .placedOrderList(placedOrderRepository.findUserPlacedOrders(id, PageRequest.of(page, size)).getContent())
                 .count(placedOrderRepository.countPlacedOrders())
                 .build();
     }
@@ -115,16 +119,13 @@ public class PlacedOrderServiceImpl implements PlacedOrderService {
 
         Shipping Information:
         -----------------------
-        Address: %s
-        City: %s
-        State: %s
-        Zip Code: %s
+        Address: %s\n        City: %s\n        State: %s\n        Zip Code: %s
 
         We appreciate your business.
         McKCreation Team
         """.formatted(
                 formattedItems,
-                order.getTotal() / 100.0,
+                order.getTotal(),
                 order.getStatus(),
                 order.getShippingDTO().getAddress(),
                 order.getShippingDTO().getCity(),
@@ -173,5 +174,43 @@ public class PlacedOrderServiceImpl implements PlacedOrderService {
 
         return sb.toString();
     }
+
+
+    // START of new methods for sales summary and pagination
+    @Override
+    public Page<PlacedOrder> getPlacedOrders(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
+        return placedOrderRepository.findAll(pageRequest);
+    }
+
+    @Override
+    public SalesSummaryDTO getSalesSummary() {
+        List<PlacedOrder> allOrders = placedOrderRepository.findAll();
+
+        LocalDateTime now = LocalDateTime.now();
+
+        double dailySales = allOrders.stream()
+                .filter(order -> order.getOrderDate().toLocalDate().isEqual(now.toLocalDate()))
+                .mapToDouble(PlacedOrder::getAmount)
+                .sum();
+
+        double monthlySales = allOrders.stream()
+                .filter(order -> order.getOrderDate().getMonth().equals(now.getMonth()) && order.getOrderDate().getYear() == now.getYear())
+                .mapToDouble(PlacedOrder::getAmount)
+                .sum();
+
+        double yearlySales = allOrders.stream()
+                .filter(order -> order.getOrderDate().getYear() == now.getYear())
+                .mapToDouble(PlacedOrder::getAmount)
+                .sum();
+
+        double allTimeSales = allOrders.stream()
+                .mapToDouble(PlacedOrder::getAmount)
+                .sum();
+
+        return new SalesSummaryDTO(dailySales, monthlySales, yearlySales, allTimeSales);
+    }
+    // END of new methods
+
 
 }

--- a/fe-app/src/App.jsx
+++ b/fe-app/src/App.jsx
@@ -28,6 +28,7 @@ import { Elements } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 import ForbiddenPage from './pages/ForbiddenPage'
 import AdminPage from './pages/AdminPage'
+import SalesSummaryPage from './pages/SalesSummaryPage'
 
 function App() {
 
@@ -70,6 +71,7 @@ function App() {
           <Route path='/account/settings' element={<AccountSettingsPage />} />
           <Route path='/account/payment-history' element={<PaymentHistoryPage />} />
           <Route path='/account/admin' element={<AdminPage />} />
+          <Route path='/account/sales' element={<SalesSummaryPage />} />
         </Route>
       </Route>
     )

--- a/fe-app/src/components/AccountNav.jsx
+++ b/fe-app/src/components/AccountNav.jsx
@@ -52,15 +52,22 @@ const AccountNav = () => {
           Payment History
         </Link>
         
-        {user.role === 'ROLE_ADMIN' ?
-        <Link
-          to="/account/admin"
-          className="text-lg font-semibold text-gray-800 hover:text-pink-500 transition duration-300"
-        >
-          Admin
-        </Link>
-        : null
-        }
+        {user.role === 'ROLE_ADMIN' ? (
+          <>
+            <Link
+              to="/account/admin"
+              className="text-lg font-semibold text-gray-800 hover:text-pink-500 transition duration-300"
+            >
+              Admin
+            </Link>
+            <Link
+              to="/account/sales"
+              className="text-lg font-semibold text-gray-800 hover:text-pink-500 transition duration-300"
+            >
+              Sales
+            </Link>
+          </>
+        ) : null}
         
         <button
           onClick={handleLogout}

--- a/fe-app/src/components/account/SalesSummary.jsx
+++ b/fe-app/src/components/account/SalesSummary.jsx
@@ -1,32 +1,234 @@
-import React from 'react'
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import PageCounter from '../PageCounter';
 
-const SalesSummary = () => {
+const PAGE_SIZE = 10;
+
+/**
+ * SalesSummary — Admin view for sales data with paginated orders and client-side page cache.
+ *
+ * Cache strategy: fetched pages are stored in pageCache (a Map held in a ref).
+ * Re-visiting a page that's already cached skips the network call entirely.
+ * Cache is invalidated when the component unmounts or the admin navigates away
+ * (intentionally session-scoped — no persistence across refreshes).
+ */
+const SalesSummary = ({ jwt }) => {
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+  // ── Sales summary ──────────────────────────────────────────────────────────
+  const [summary, setSummary] = useState(null);
+  const [summaryLoading, setSummaryLoading] = useState(true);
+  const [summaryError, setSummaryError] = useState(null);
+
+  // ── Paginated orders ───────────────────────────────────────────────────────
+  const [page, setPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [orders, setOrders] = useState([]);
+  const [ordersLoading, setOrdersLoading] = useState(true);
+  const [ordersError, setOrdersError] = useState(null);
+
+  // ── Client-side page cache  ────────────────────────────────────────────────
+  // Map<pageNumber, { orders: PlacedOrder[], totalPages: number }>
+  const pageCache = useRef(new Map());
+
+  // ── Fetch sales summary (once) ─────────────────────────────────────────────
+  useEffect(() => {
+    const controller = new AbortController();
+    setSummaryLoading(true);
+    setSummaryError(null);
+
+    fetch(`${API_BASE_URL}/api/placed-orders/sales-summary`, {
+      signal: controller.signal,
+      headers: { Authorization: `Bearer ${jwt}` },
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json();
+      })
+      .then((data) => {
+        setSummary(data);
+        setSummaryLoading(false);
+      })
+      .catch((err) => {
+        if (err?.name !== 'AbortError') {
+          setSummaryError('Failed to load sales summary.');
+          setSummaryLoading(false);
+        }
+      });
+
+    return () => controller.abort();
+  }, [API_BASE_URL, jwt]);
+
+  // ── Fetch paginated orders (with cache) ────────────────────────────────────
+  const fetchPage = useCallback(
+    (targetPage) => {
+      // Cache hit — no network call needed
+      if (pageCache.current.has(targetPage)) {
+        const cached = pageCache.current.get(targetPage);
+        setOrders(cached.orders);
+        setTotalPages(cached.totalPages);
+        setOrdersLoading(false);
+        return;
+      }
+
+      const controller = new AbortController();
+      setOrdersLoading(true);
+      setOrdersError(null);
+
+      const url = new URL(`${API_BASE_URL}/api/placed-orders`);
+      url.searchParams.set('page', targetPage);
+      url.searchParams.set('size', PAGE_SIZE);
+
+      fetch(url.toString(), {
+        signal: controller.signal,
+        headers: { Authorization: `Bearer ${jwt}` },
+      })
+        .then((res) => {
+          if (!res.ok) throw new Error(`HTTP ${res.status}`);
+          return res.json();
+        })
+        .then((data) => {
+          // Spring Page response shape: { content, totalPages, totalElements, ... }
+          const fetched = {
+            orders: data.content ?? [],
+            totalPages: data.totalPages ?? 1,
+          };
+          pageCache.current.set(targetPage, fetched);
+          setOrders(fetched.orders);
+          setTotalPages(fetched.totalPages);
+          setOrdersLoading(false);
+        })
+        .catch((err) => {
+          if (err?.name !== 'AbortError') {
+            setOrdersError('Failed to load orders.');
+            setOrdersLoading(false);
+          }
+        });
+
+      // We don't abort here since page changes are synchronous user actions;
+      // the cache prevents double-fetching the same page.
+    },
+    [API_BASE_URL, jwt]
+  );
+
+  // ── Trigger fetch whenever page changes ───────────────────────────────────
+  useEffect(() => {
+    fetchPage(page);
+  }, [page, fetchPage]);
+
+  // ── Helpers ────────────────────────────────────────────────────────────────
+  const fmt = (val) =>
+    val != null
+      ? `$${Number(val).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+      : '—';
+
+  const formatDate = (raw) => {
+    if (!raw) return '—';
+    return new Date(raw).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  };
+
+  // ── Render ─────────────────────────────────────────────────────────────────
   return (
-    <section className='text-center m-10'>
-      <h1 className='text-3xl'>Sales Summary</h1>
-      <div className='flex flex-wrap w-160 m-auto items-center justify-around'>
-        <div className='flex justify-center items-center border border-black flex-col w-72 h-56 bg-pink-400 mt-10'>
-          <h1 className='text-3xl'>Daily sales</h1>
-          <h1 className='text-3xl mt-5'>$0</h1>
-        </div>
+    <section className="text-center m-10">
+      <h1 className="text-3xl font-bold mb-8">Sales Summary</h1>
 
-        <div className='flex justify-center items-center border border-black flex-col w-72 h-56 bg-pink-400 mt-10'>
-          <h1 className='text-3xl'>Monthly sales</h1>
-          <h1 className='text-3xl mt-5'>$0</h1>
-        </div>
+      {/* ── Summary cards ── */}
+      {summaryError && (
+        <p className="text-red-500 mb-4">{summaryError}</p>
+      )}
 
-        <div className='flex justify-center items-center border border-black flex-col w-72 h-56 bg-pink-400 mt-10'>
-          <h1 className='text-3xl'>Yearly sales</h1>
-          <h1 className='text-3xl mt-5'>$0</h1>
-        </div>
+      <div className="flex flex-wrap w-full max-w-4xl m-auto items-center justify-around mb-12">
+        {[
+          { label: 'Daily Sales', key: 'dailySales' },
+          { label: 'Monthly Sales', key: 'monthlySales' },
+          { label: 'Yearly Sales', key: 'yearlySales' },
+          { label: 'All Time Sales', key: 'allTimeSales' },
+        ].map(({ label, key }) => (
+          <div
+            key={key}
+            className="flex justify-center items-center border border-black flex-col w-72 h-56 bg-pink-400 mt-10 rounded-lg shadow"
+          >
+            <h2 className="text-2xl font-semibold">{label}</h2>
+            <p className="text-3xl mt-5 font-bold">
+              {summaryLoading ? '…' : fmt(summary?.[key])}
+            </p>
+          </div>
+        ))}
+      </div>
 
-        <div className='flex justify-center items-center border border-black flex-col w-72 h-56 bg-pink-400 mt-10'>
-          <h1 className='text-3xl'>All time sales</h1>
-          <h1 className='text-3xl mt-5'>$0</h1>
-        </div>
+      {/* ── Orders table ── */}
+      <h2 className="text-2xl font-semibold mb-4">All Orders</h2>
+
+      {ordersError && <p className="text-red-500 mb-4">{ordersError}</p>}
+
+      <div className="overflow-x-auto max-w-5xl mx-auto">
+        <table className="min-w-full bg-white shadow-md rounded-lg overflow-hidden text-left">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="py-2 px-4">Order ID</th>
+              <th className="py-2 px-4">Status</th>
+              <th className="py-2 px-4">Amount</th>
+              <th className="py-2 px-4">Customer</th>
+              <th className="py-2 px-4">Date</th>
+            </tr>
+          </thead>
+          <tbody>
+            {ordersLoading ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-center text-gray-400">
+                  Loading…
+                </td>
+              </tr>
+            ) : orders.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-6 text-center text-gray-400">
+                  No orders found.
+                </td>
+              </tr>
+            ) : (
+              orders.map((order) => (
+                <tr key={order.id} className="border-t hover:bg-gray-50 transition">
+                  <td className="py-2 px-4 font-mono text-sm">{order.id}</td>
+                  <td className="py-2 px-4">
+                    <span
+                      className={`px-2 py-1 rounded-full text-xs font-semibold ${
+                        order.status === 'COMPLETED'
+                          ? 'bg-green-100 text-green-700'
+                          : order.status === 'PENDING'
+                          ? 'bg-yellow-100 text-yellow-700'
+                          : 'bg-gray-100 text-gray-600'
+                      }`}
+                    >
+                      {order.status ?? '—'}
+                    </span>
+                  </td>
+                  <td className="py-2 px-4">{fmt(order.amount)}</td>
+                  <td className="py-2 px-4">
+                    {order.user
+                      ? `${order.user.firstName ?? ''} ${order.user.lastName ?? ''}`.trim() || order.user.email
+                      : '—'}
+                  </td>
+                  <td className="py-2 px-4">{formatDate(order.orderDate)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* ── Pagination ── */}
+      <div className="mt-6 mb-4">
+        <PageCounter
+          page={page}
+          totalPages={totalPages}
+          onPageChange={setPage}
+        />
       </div>
     </section>
-  )
-}
+  );
+};
 
-export default SalesSummary
+export default SalesSummary;

--- a/fe-app/src/pages/SalesSummaryPage.jsx
+++ b/fe-app/src/pages/SalesSummaryPage.jsx
@@ -1,10 +1,24 @@
-import React from 'react'
-import SalesSummary from '../components/account/SalesSummary'
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { jwtDecode } from 'jwt-decode';
+import SalesSummary from '../components/account/SalesSummary';
 
 const SalesSummaryPage = () => {
-  return (
-    <SalesSummary />
-  )
-}
+  const jwt = localStorage.getItem('jwt');
+  const nav = useNavigate();
 
-export default SalesSummaryPage
+  useEffect(() => {
+    if (!jwt) {
+      nav('/account/login');
+      return;
+    }
+    const decoded = jwtDecode(jwt);
+    if (decoded.role !== 'ROLE_ADMIN') {
+      nav('/forbidden');
+    }
+  }, []);
+
+  return <SalesSummary jwt={jwt} />;
+};
+
+export default SalesSummaryPage;


### PR DESCRIPTION
## Summary

This PR implements sales pagination and a sales summary dashboard for the admin panel.

## Changes

### Backend
- **New endpoint** `GET /api/placed-orders?page=0&size=10` — returns paginated `Page<PlacedOrder>`
- **New endpoint** `GET /api/placed-orders/sales-summary` — returns daily/monthly/yearly/all-time sales totals
- **Security fix**: Both new endpoints restricted to `ADMIN` role (previously fell through to `anyRequest().authenticated()`)
- **Performance fix**: Sales aggregation now uses DB-level JPQL `SUM` queries instead of loading all orders into memory
- New `SalesSummaryDTO` response object

### Frontend
- New `SalesSummary` admin component with summary cards and paginated orders table
- Client-side page cache using `useRef(Map)` — revisiting a page skips the network call
- Reusable `PageCounter` component with ellipsis support
- Follows existing Tailwind/pink theme

## Notes
- `application.properties` and `.env` files are excluded from this PR
- Reviewed and approved by Mona (manager)